### PR TITLE
Nvmf rdma srq

### DIFF
--- a/configure
+++ b/configure
@@ -47,6 +47,8 @@ function usage()
 	echo "                           No path required."
 	echo " rdma                      [disabled]"
 	echo "                           No path required."
+	echo " rdma-srq                  [disabled]"
+	echo "                           No path required."
 	echo " iscsi-initiator           [disabled]"
 	echo "                           No path required."
 	echo " raid                      [disabled]"
@@ -150,6 +152,12 @@ for i in "$@"; do
 			;;
 		--without-rdma)
 			CONFIG_RDMA=n
+			;;
+		--with-rdma-srq)
+			CONFIG_RDMA_SRQ=y
+			;;
+		--without-rdma-srq)
+			CONFIG_RDMA_SRQ=n
 			;;
 		--with-iscsi-initiator)
 			CONFIG_ISCSI_INITIATOR=y
@@ -329,6 +337,9 @@ if [ -n "$FIO_SOURCE_DIR" ]; then
 fi
 if [ -n "$CONFIG_RDMA" ]; then
 	echo "CONFIG_RDMA?=$CONFIG_RDMA" >> CONFIG.local
+fi
+if [ -n "$CONFIG_RDMA_SRQ" ]; then
+	echo "CONFIG_RDMA_SRQ?=$CONFIG_RDMA_SRQ" >> CONFIG.local
 fi
 if [ -n "$CONFIG_ISCSI_INITIATOR" ]; then
 	echo "CONFIG_ISCSI_INITIATOR?=$CONFIG_ISCSI_INITIATOR" >> CONFIG.local

--- a/configure
+++ b/configure
@@ -46,7 +46,7 @@ function usage()
 	echo " rbd                       [disabled]"
 	echo "                           No path required."
 	echo " rdma                      [disabled]"
-	echo "                           No path required."
+	echo "                           Path to RDMA library build/install directory may be optionally specified. If no path has been provided system libraries will be used."
 	echo " rdma-srq                  [disabled]"
 	echo "                           No path required."
 	echo " iscsi-initiator           [disabled]"
@@ -150,8 +150,14 @@ for i in "$@"; do
 		--with-rdma)
 			CONFIG_RDMA=y
 			;;
+		--with-rdma=*)
+			CONFIG_RDMA=y
+			check_dir "$i"
+			RDMA_SOURCE_DIR=$(readlink -f ${i#*=})
+			;;
 		--without-rdma)
 			CONFIG_RDMA=n
+			RDMA_SOURCE_DIR=
 			;;
 		--with-rdma-srq)
 			CONFIG_RDMA_SRQ=y
@@ -337,6 +343,9 @@ if [ -n "$FIO_SOURCE_DIR" ]; then
 fi
 if [ -n "$CONFIG_RDMA" ]; then
 	echo "CONFIG_RDMA?=$CONFIG_RDMA" >> CONFIG.local
+fi
+if [ -n "$RDMA_SOURCE_DIR" ]; then
+	echo "RDMA_SOURCE_DIR?=$RDMA_SOURCE_DIR" >> CONFIG.local
 fi
 if [ -n "$CONFIG_RDMA_SRQ" ]; then
 	echo "CONFIG_RDMA_SRQ?=$CONFIG_RDMA_SRQ" >> CONFIG.local

--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -64,6 +64,7 @@ struct spdk_json_write_ctx;
 
 struct spdk_nvmf_tgt_opts {
 	uint16_t max_queue_depth;
+	uint16_t max_srqueue_depth;
 	uint16_t max_qpairs_per_ctrlr;
 	uint32_t in_capsule_data_size;
 	uint32_t max_io_size;

--- a/lib/event/subsystems/nvmf/conf.c
+++ b/lib/event/subsystems/nvmf/conf.c
@@ -68,6 +68,7 @@ spdk_nvmf_read_config_file_tgt_opts(struct spdk_conf_section *sp,
 				    struct spdk_nvmf_tgt_opts *opts)
 {
 	int max_queue_depth;
+	int max_srqueue_depth;
 	int max_queues_per_sess;
 	int in_capsule_data_size;
 	int max_io_size;
@@ -76,6 +77,11 @@ spdk_nvmf_read_config_file_tgt_opts(struct spdk_conf_section *sp,
 	max_queue_depth = spdk_conf_section_get_intval(sp, "MaxQueueDepth");
 	if (max_queue_depth >= 0) {
 		opts->max_queue_depth = max_queue_depth;
+	}
+
+	max_srqueue_depth = spdk_conf_section_get_intval(sp, "MaxSRQueueDepth");
+	if (max_srqueue_depth >= 0) {
+		opts->max_srqueue_depth = max_srqueue_depth;
 	}
 
 	max_queues_per_sess = spdk_conf_section_get_intval(sp, "MaxQueuesPerSession");

--- a/lib/event/subsystems/nvmf/nvmf_rpc.c
+++ b/lib/event/subsystems/nvmf/nvmf_rpc.c
@@ -1564,6 +1564,7 @@ SPDK_RPC_REGISTER("nvmf_subsystem_allow_any_host", nvmf_rpc_subsystem_allow_any_
 
 static const struct spdk_json_object_decoder nvmf_rpc_subsystem_tgt_opts_decoder[] = {
 	{"max_queue_depth", offsetof(struct spdk_nvmf_tgt_opts, max_queue_depth), spdk_json_decode_uint16, true},
+	{"max_srqueue_depth", offsetof(struct spdk_nvmf_tgt_opts, max_srqueue_depth), spdk_json_decode_uint16, true},
 	{"max_qpairs_per_ctrlr", offsetof(struct spdk_nvmf_tgt_opts, max_qpairs_per_ctrlr), spdk_json_decode_uint16, true},
 	{"in_capsule_data_size", offsetof(struct spdk_nvmf_tgt_opts, in_capsule_data_size), spdk_json_decode_uint32, true},
 	{"max_io_size", offsetof(struct spdk_nvmf_tgt_opts, max_io_size), spdk_json_decode_uint32, true},

--- a/lib/nvmf/nvmf.c
+++ b/lib/nvmf/nvmf.c
@@ -50,6 +50,7 @@
 SPDK_LOG_REGISTER_COMPONENT("nvmf", SPDK_LOG_NVMF)
 
 #define SPDK_NVMF_DEFAULT_MAX_QUEUE_DEPTH 128
+#define SPDK_NVMF_DEFAULT_MAX_SRQUEUE_DEPTH 4096
 #define SPDK_NVMF_DEFAULT_MAX_QPAIRS_PER_CTRLR 64
 #define SPDK_NVMF_DEFAULT_IN_CAPSULE_DATA_SIZE 4096
 #define SPDK_NVMF_DEFAULT_MAX_IO_SIZE 131072
@@ -67,6 +68,7 @@ void
 spdk_nvmf_tgt_opts_init(struct spdk_nvmf_tgt_opts *opts)
 {
 	opts->max_queue_depth = SPDK_NVMF_DEFAULT_MAX_QUEUE_DEPTH;
+	opts->max_srqueue_depth = SPDK_NVMF_DEFAULT_MAX_SRQUEUE_DEPTH;
 	opts->max_qpairs_per_ctrlr = SPDK_NVMF_DEFAULT_MAX_QPAIRS_PER_CTRLR;
 	opts->in_capsule_data_size = SPDK_NVMF_DEFAULT_IN_CAPSULE_DATA_SIZE;
 	opts->max_io_size = SPDK_NVMF_DEFAULT_MAX_IO_SIZE;
@@ -210,6 +212,7 @@ spdk_nvmf_tgt_create(struct spdk_nvmf_tgt_opts *opts)
 	SPDK_DEBUGLOG(SPDK_LOG_NVMF, "Max Queue Pairs Per Controller: %d\n",
 		      tgt->opts.max_qpairs_per_ctrlr);
 	SPDK_DEBUGLOG(SPDK_LOG_NVMF, "Max Queue Depth: %d\n", tgt->opts.max_queue_depth);
+	SPDK_DEBUGLOG(SPDK_LOG_NVMF, "Max Shared Receive Queue Depth: %d\n", tgt->opts.max_srqueue_depth);
 	SPDK_DEBUGLOG(SPDK_LOG_NVMF, "Max In Capsule Data: %d bytes\n",
 		      tgt->opts.in_capsule_data_size);
 	SPDK_DEBUGLOG(SPDK_LOG_NVMF, "Max I/O Size: %d bytes\n", tgt->opts.max_io_size);
@@ -392,6 +395,7 @@ spdk_nvmf_tgt_write_config_json(struct spdk_json_write_ctx *w, struct spdk_nvmf_
 
 	spdk_json_write_named_object_begin(w, "params");
 	spdk_json_write_named_uint32(w, "max_queue_depth", tgt->opts.max_queue_depth);
+	spdk_json_write_named_uint32(w, "max_srqueue_depth", tgt->opts.max_srqueue_depth);
 	spdk_json_write_named_uint32(w, "max_qpairs_per_ctrlr", tgt->opts.max_qpairs_per_ctrlr);
 	spdk_json_write_named_uint32(w, "in_capsule_data_size", tgt->opts.in_capsule_data_size);
 	spdk_json_write_named_uint32(w, "max_io_size", tgt->opts.max_io_size);

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -2012,7 +2012,7 @@ spdk_nvmf_rdma_poll_group_create(struct spdk_nvmf_transport *transport)
 		}
 
 		if (!poller->cmds_mr || !poller->cpls_mr || (rtransport->in_capsule_data_size &&
-							     !poller->bufs_mr)) {
+				!poller->bufs_mr)) {
 			SPDK_ERRLOG("Unable to register required memory for RDMA shared queue.\n");
 			spdk_nvmf_rdma_poll_group_destroy(&rgroup->group);
 			pthread_mutex_unlock(&rtransport->lock);
@@ -2337,10 +2337,10 @@ spdk_nvmf_rdma_qpair_process_pending(struct spdk_nvmf_rdma_transport *rtransport
 }
 
 #ifdef SPDK_CONFIG_RDMA_SRQ
-static struct spdk_nvmf_rdma_qpair*
+static struct spdk_nvmf_rdma_qpair *
 get_rdma_qpair_from_wc(struct spdk_nvmf_rdma_poller *rpoller, struct ibv_wc *wc)
 {
-	struct spdk_nvmf_rdma_qpair* rqpair;
+	struct spdk_nvmf_rdma_qpair *rqpair;
 	/* @todo: improve QP search */
 	TAILQ_FOREACH(rqpair, &rpoller->qpairs, link) {
 		if (wc->qp_num == rqpair->cm_id->qp->qp_num) {

--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -1150,7 +1150,7 @@ spdk_nvmf_rdma_cur_queue_depth(struct spdk_nvmf_rdma_qpair *rqpair)
 {
 #ifndef SPDK_CONFIG_RDMA_SRQ
 	return rqpair->max_queue_depth -
-	       [RDMA_REQUEST_STATE_FREE];
+	       rqpair->state_cntr[RDMA_REQUEST_STATE_FREE];
 #else
 	int i, sum = 0;
 	for (i = RDMA_REQUEST_STATE_FREE; i < RDMA_REQUEST_NUM_STATES; i++) {
@@ -2480,8 +2480,8 @@ spdk_nvmf_rdma_poller_poll(struct spdk_nvmf_rdma_transport *rtransport,
 #else
 			TAILQ_INSERT_TAIL(&rpoller->incoming_queue, rdma_recv, link);
 #endif
-			SPDK_ERRLOG("Received command on the CQ: wc.qp_num %u, qp.qp_num %u\n",
-				    wc[i].qp_num, rqpair->cm_id->qp->qp_num);
+			/*SPDK_ERRLOG("Received command on the CQ: wc.qp_num %u, qp.qp_num %u\n",
+			  wc[i].qp_num, rqpair->cm_id->qp->qp_num);*/
 
 			/* Try to process other queued requests */
 			spdk_nvmf_rdma_qpair_process_pending(rtransport, rqpair);

--- a/lib/nvmf/transport.c
+++ b/lib/nvmf/transport.c
@@ -120,6 +120,9 @@ spdk_nvmf_transport_poll_group_create(struct spdk_nvmf_transport *transport)
 	struct spdk_nvmf_transport_poll_group *group;
 
 	group = transport->ops->poll_group_create(transport);
+	if (!group) {
+		return NULL;
+	}
 	group->transport = transport;
 
 	return group;

--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -125,6 +125,11 @@ LIBS += -L$(CONFIG_VPP_DIR)/lib64
 COMMON_CFLAGS += -I$(CONFIG_VPP_DIR)/include
 endif
 
+ifneq ($(RDMA_SOURCE_DIR),)
+LIBS += -L$(RDMA_SOURCE_DIR)/lib
+COMMON_CFLAGS += -I$(RDMA_SOURCE_DIR)/include
+endif
+
 #Attach only if FreeBSD and RDMA is specified with configure
 ifeq ($(OS),FreeBSD)
 ifeq ($(CONFIG_RDMA),y)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -1087,6 +1087,7 @@ if __name__ == "__main__":
     def set_nvmf_target_options(args):
         rpc.nvmf.set_nvmf_target_options(args.client,
                                          max_queue_depth=args.max_queue_depth,
+                                         max_srqueue_depth=args.max_srqueue_depth,
                                          max_qpairs_per_ctrlr=args.max_qpairs_per_ctrlr,
                                          in_capsule_data_size=args.in_capsule_data_size,
                                          max_io_size=args.max_io_size,
@@ -1095,6 +1096,7 @@ if __name__ == "__main__":
 
     p = subparsers.add_parser('set_nvmf_target_options', help='Set NVMf target options')
     p.add_argument('-q', '--max-queue-depth', help='Max number of outstanding I/O per queue', type=int)
+    p.add_argument('-s', '--max-srqueue-depth', help='Max number of outstanding I/O per shared queue', type=int)
     p.add_argument('-p', '--max-qpairs-per-ctrlr', help='Max number of SQ and CQ per controller', type=int)
     p.add_argument('-c', '--in-capsule-data-size', help='Max number of in-capsule data size', type=int)
     p.add_argument('-i', '--max-io-size', help='Max I/O size (bytes)', type=int)

--- a/scripts/rpc/nvmf.py
+++ b/scripts/rpc/nvmf.py
@@ -2,6 +2,7 @@
 
 def set_nvmf_target_options(client,
                             max_queue_depth=None,
+                            max_srqueue_depth=None,
                             max_qpairs_per_ctrlr=None,
                             in_capsule_data_size=None,
                             max_io_size=None,
@@ -11,6 +12,7 @@ def set_nvmf_target_options(client,
 
     Args:
         max_queue_depth: Max number of outstanding I/O per queue (optional)
+        max_srqueue_depth: Max number of outstanding I/O per shared queue (optional)
         max_qpairs_per_ctrlr: Max number of SQ and CQ per controller (optional)
         in_capsule_data_size: Maximum in-capsule data size in bytes (optional)
         max_io_size: Maximum I/O data size in bytes (optional)
@@ -24,6 +26,8 @@ def set_nvmf_target_options(client,
 
     if max_queue_depth:
         params['max_queue_depth'] = max_queue_depth
+    if max_srqueue_depth:
+        params['max_srqueue_depth'] = max_srqueue_depth
     if max_qpairs_per_ctrlr:
         params['max_qpairs_per_ctrlr'] = max_qpairs_per_ctrlr
     if in_capsule_data_size:


### PR DESCRIPTION
The first implementation of SRQ in RDMA transport. SRQ is created per thread and device (spdk_nvmf_rdma_poller structure). All changes are currently done under compile time flag. Existing Nvmf configuration parameter MaxQueueDepth is reused to set the size of SRQ.