### PR TITLE
Fix src.rpm generation for MOFED builder

### DIFF
--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -4,6 +4,7 @@ wd=$(dirname $0)
 wdir=$(dirname $wd)
 cd $wdir
 mkdir -p $HOME/rpmbuild/{SOURCES,RPMS,SRPMS,SPECS,BUILD,BUILDROOT}
+OUTDIR=$HOME/rpmbuild/SOURCES
 set -e
 if [ -z "$VER" ] ; then
     export VER=20.04.1
@@ -19,7 +20,7 @@ sed -e "s#scm_rev %{_rev}#scm_rev ${BUILD_NUMBER:-1}#" scripts/spdk.spec > $OUT_
 sed -i "s#%{_date}#$_date#; s#%{_sha1}#$sha1#; s#%{_branch}#$branch# " $OUT_SPEC
 
 git archive \
-    --format=tar.gz --prefix=spdk-$VER/ -o ~/rpmbuild/SOURCES/spdk-$VER.tar.gz  HEAD
+    --format=tar --prefix=spdk-$VER/ -o $OUTDIR/spdk-$VER.tar  HEAD
 # echo ***********
 # ls -l ~/rpmbuild/SOURCES/spdk-$VER.tar.gz
 # echo ***********
@@ -29,23 +30,17 @@ for MOD in $(git submodule |awk '{print $2}')
 do
   (cd $MOD;
    git archive \
-    --format=tar.gz --prefix=$MOD/ -o ~/rpmbuild/SOURCES/spdk-$MOD-$VER.tar.gz  HEAD
+    --format=tar --prefix=spdk-$VER/$MOD/ -o $OUTDIR/spdk-$MOD-$VER.tar  HEAD
   )
 done
-
+for MOD in $(git submodule |awk '{print $2}')
+do
+    tar --concatenate --file=$OUTDIR/spdk-$VER.tar $OUTDIR/spdk-$MOD-$VER.tar 
+done
+gzip $OUTDIR/spdk-$VER.tar
 # BUILD_NUMBER is an env var passed by Jenkins
 # https://stackoverflow.com/questions/16155792/using-jenkins-build-number-in-rpm-spec-file
 fakeroot  \
   rpmbuild -bs --define "dist %{nil}" $args $OUT_SPEC
 
-# Let's assume all dependencies are already installed
-# into *spdk_dev docker image
-#--
-# if [ "$UID" -eq 0 ] ; then
-#    chown 0.0  ~/rpmbuild/SOURCES/spdk-*-$VER.tar.gz
-#    # ls -l ~/rpmbuild/SOURCES/*
-#    # just a workaround for missed *-source repos:
-#    fgrep -l vault.centos /etc/yum.repos.d/*.repo |while read fn ; do mv $fn /tmp/ ; done
-#    yum-builddep -y $OUT_SPEC
-# fi
-rpmbuild -bb $args  $OUT_SPEC
+# rpmbuild -bb $args  $OUT_SPEC

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+#
+function get_ver()
+{
+    by_tag=$(git describe HEAD --tags)
+    v_pfx=${by_tag%%-*}
+    v_num=${v_pfx#v}
+    echo $v_num
+}
+function generate_changelog()
+{
+    today=$(date +"%a, %d %b %Y %T %z")
+    mkdir -p spdk-$VER/debian/
+    mkdir -p spdk-$VER/scripts/debian/
+
+    for FN in debian/changelog scripts/debian/changelog ; do
+      sed -e "s/@PACKAGE_VERSION@/$VER/" -e "s/@PACKAGE_REVISION@/${BUILD_NUMBER-1}/" \
+          -e 's/@PACKAGE_BUGREPORT@/support@mellanox.com/' -e "s/@BUILD_DATE_CHANGELOG@/$today/" \
+          $FN.in > spdk-$VER/$FN
+    done
+}
 args="$@"
 wd=$(dirname $0)
 wdir=$(dirname $wd)
@@ -7,7 +27,11 @@ mkdir -p $HOME/rpmbuild/{SOURCES,RPMS,SRPMS,SPECS,BUILD,BUILDROOT}
 OUTDIR=$HOME/rpmbuild/SOURCES
 set -e
 if [ -z "$VER" ] ; then
-    export VER=20.04.1
+    VER=$(get_ver)
+    if [ -z "$VER" ] ; then
+        VER=20.04.1
+    fi
+    export VER
 fi
 branch=$(git rev-parse --abbrev-ref HEAD)
 sha1=$(git rev-parse HEAD |cut -c -8)
@@ -21,6 +45,9 @@ sed -i "s#%{_date}#$_date#; s#%{_sha1}#$sha1#; s#%{_branch}#$branch# " $OUT_SPEC
 
 git archive \
     --format=tar --prefix=spdk-$VER/ -o $OUTDIR/spdk-$VER.tar  HEAD
+generate_changelog
+tar -uf  $OUTDIR/spdk-$VER.tar spdk-$VER/debian/changelog spdk-$VER/scripts/debian/changelog
+rm -rf spdk-$VER/
 # echo ***********
 # ls -l ~/rpmbuild/SOURCES/spdk-$VER.tar.gz
 # echo ***********
@@ -37,10 +64,10 @@ for MOD in $(git submodule |awk '{print $2}')
 do
     tar --concatenate --file=$OUTDIR/spdk-$VER.tar $OUTDIR/spdk-$MOD-$VER.tar 
 done
-gzip $OUTDIR/spdk-$VER.tar
+gzip -c $OUTDIR/spdk-$VER.tar >$OUTDIR/spdk-$VER.tar.gz
 # BUILD_NUMBER is an env var passed by Jenkins
 # https://stackoverflow.com/questions/16155792/using-jenkins-build-number-in-rpm-spec-file
 fakeroot  \
   rpmbuild -bs --define "dist %{nil}" $args $OUT_SPEC
 
-# rpmbuild -bb $args  $OUT_SPEC
+#rpmbuild -bb $args $OUT_SPEC

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -70,4 +70,4 @@ gzip -c $OUTDIR/spdk-$VER.tar >$OUTDIR/spdk-$VER.tar.gz
 fakeroot  \
   rpmbuild -bs --define "dist %{nil}" $args $OUT_SPEC
 
-#rpmbuild -bb $args $OUT_SPEC
+rpmbuild -bb $args $OUT_SPEC

--- a/scripts/spdk.spec
+++ b/scripts/spdk.spec
@@ -17,10 +17,10 @@ Group: 		System Environment/Daemons
 License: 	BSD and LGPLv2 and GPLv2
 URL: 		http://www.spdk.io
 Source0:	spdk-%{version}.tar.gz
-Source1:	spdk-dpdk-%{version}.tar.gz
-Source2:	spdk-intel-ipsec-mb-%{version}.tar.gz
-Source3:	spdk-isa-l-%{version}.tar.gz
-Source4:	spdk-ocf-%{version}.tar.gz
+#Source1:	spdk-dpdk-%{version}.tar.gz
+#Source2:	spdk-intel-ipsec-mb-%{version}.tar.gz
+#Source3:	spdk-isa-l-%{version}.tar.gz
+#Source4:	spdk-ocf-%{version}.tar.gz
 
 %define package_version %{epoch}:%{version}-%{release}
 %define install_datadir %{buildroot}/%{_datadir}/%{name}
@@ -38,6 +38,17 @@ Source4:	spdk-ocf-%{version}.tar.gz
 # on Fedora 28+ we have python3 == 3.7
 %define use_python python3
 %define python_ver 3.7
+%ifarch x86_64
+BuildRequires:  clang-analyzer
+%endif
+# Additional dependencies for building docs
+# not present @ CentOS-7.4 w/o EPEL:
+# - mscgen 
+# - astyle-devel
+%ifarch x86_64
+# Additional dependencies for building pmem based backends
+# BuildRequires:	libpmemblk-devel
+%endif
 %endif
 
 ExclusiveArch: x86_64 aarch64
@@ -67,19 +78,8 @@ BuildRequires:	git make gcc gcc-c++
 BuildRequires:	CUnit-devel, libaio-devel, openssl-devel, libuuid-devel 
 BuildRequires:	libiscsi-devel
 BuildRequires:  lcov
-%ifarch x86_64
-BuildRequires:  clang-analyzer
-%endif
 # Additional dependencies for NVMe over Fabrics
 BuildRequires:	libibverbs-devel, librdmacm-devel
-# Additional dependencies for building docs
-# not present @ CentOS-7.4 w/o EPEL:
-# - mscgen 
-# - astyle-devel
-%ifarch x86_64
-# Additional dependencies for building pmem based backends
-# BuildRequires:	libpmemblk-devel
-%endif
 
 # Build python36 from IUS repo and install on CentOS/7
 # -- https://github.com/iusrepo/python36/blob/master/python36.spec
@@ -108,10 +108,10 @@ applications.
 
 %prep
 %setup -q
-tar zxf %{SOURCE1}
-tar zxf %{SOURCE2}
-tar zxf %{SOURCE3}
-tar zxf %{SOURCE4}
+#tar zxf %{SOURCE1}
+#tar zxf %{SOURCE2}
+#tar zxf %{SOURCE3}
+#tar zxf %{SOURCE4}
 # test -e ./dpdk/config/common_linuxapp
 
 %build


### PR DESCRIPTION
MOFED builder takes orig.tar.gz from src.rpm to build DEB package.
The orig.tar.gz should contain code from all submodules