### PR TITLE
Deb packages: change python3.X dependencies

### DIFF
--- a/scripts/debian/control
+++ b/scripts/debian/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 10), dh-python, python3-distutils
 Standards-Version: 4.1.2
 Homepage: https://spdk.io/
 #X-Python-Version: 2.7
-XS-Python-Version: 3.6
-X-Python3-Version: 3.6
+#XS-Python-Version: 3.6
+#X-Python3-Version: 3.6
 #Vcs-Git: https://anonscm.debian.org/git/collab-maint/spdk.git
 #Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/spdk.git
 

--- a/scripts/debian/rules
+++ b/scripts/debian/rules
@@ -3,7 +3,7 @@ export DH_VERBOSE=1
 export PYBUILD_NAME=spdk-rpc
 export PYBUILD_INTERPRETERS=python{version}
 # python{version}-dbg
-export PYBUILD_VERSIONS=3.6
+export PYBUILD_VERSIONS=3
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
Change dependencies python3.X -> python3 for Debian packages.

Tests:
- build DEB package for Ubuntu 20.04 BFB
- install DEB on Ubuntu 20.04 BFB
- Test tools: snap_rpc.py, spdk_rpc.py

Signed-off-by: Max Umanskyi <maksymu@mellanox.com>