### PR TITLE
Added functions to control the cache eviction

### DIFF
--- a/include/spdk/nvmf.h
+++ b/include/spdk/nvmf.h
@@ -125,6 +125,8 @@ struct spdk_nvmf_io_pacer_stat {
 	uint64_t calls;
 	uint64_t no_ios;
 	uint64_t period_ticks;
+	uint64_t nos_credit_unavailable;
+	uint64_t nos_bytes_above_allowed;
 };
 
 struct spdk_nvmf_transport_poll_group_stat {

--- a/lib/nvmf/io_pacer.c
+++ b/lib/nvmf/io_pacer.c
@@ -490,7 +490,7 @@ io_pacer_tune2(void *arg)
 	new_period_ticks = spdk_min(new_period_ticks, tuner->max_pacer_period_ticks);
 
 	static __thread uint32_t log_counter = 0;
-	/* Try to log once per second */
+	/* Try to log once per second, to limit the log */
 	if (log_counter % (SPDK_SEC_TO_NSEC / tuner->period_ns) == 0) {
 		SPDK_NOTICELOG("IO pacer tuner %p: pacer %p, value %u, new period %lu ticks, min %lu, polls %u. ios %u\n",
 			       tuner,

--- a/lib/nvmf/io_pacer.c
+++ b/lib/nvmf/io_pacer.c
@@ -395,7 +395,7 @@ io_pacer_tune(void *arg)
 				    tuner->min_pacer_period_ticks);
 
 	static __thread uint32_t log_counter = 0;
-	/* Try to log once per second */
+	/* Try to log once per second so as to reduce num of traces */
 	if (log_counter % (SPDK_SEC_TO_NSEC / tuner->period_ns) == 0) {
 		SPDK_NOTICELOG("IO pacer tuner %p: pacer %p, bytes %lu, io period %lu ns, new period %lu ns, new period %lu ticks, min %lu, max %lu\n",
 			       tuner,

--- a/lib/nvmf/io_pacer.c
+++ b/lib/nvmf/io_pacer.c
@@ -490,7 +490,7 @@ io_pacer_tune2(void *arg)
 	new_period_ticks = spdk_min(new_period_ticks, tuner->max_pacer_period_ticks);
 
 	static __thread uint32_t log_counter = 0;
-	/* Try to log once per second, else it would be too much log  */
+	/* Try to log once per second */
 	if (log_counter % (SPDK_SEC_TO_NSEC / tuner->period_ns) == 0) {
 		SPDK_NOTICELOG("IO pacer tuner %p: pacer %p, value %u, new period %lu ticks, min %lu, polls %u. ios %u\n",
 			       tuner,

--- a/lib/nvmf/io_pacer.h
+++ b/lib/nvmf/io_pacer.h
@@ -42,6 +42,32 @@
 #include "spdk_internal/log.h"
 #include "spdk/nvmf.h"
 
+/* Tuner types
+*/
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_01  01
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_02  02
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03  03
+
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_01  01 /* Bytes in flight */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_02  02 /* Avg Bytes in flght for N pacer periods */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_03  03 /* Read/Write Bytes in flight */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_04  04 /* Margin Bytes Range in flight */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_05  05 /* Margin proportionate Bytes Range in flight */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_06  06 /* Margin Inc/Dec w.r.t allowed bytes */
+#define SPDK_NVMF_RDMA_IO_PACER_TUNER_TYPE_03_PROPOSAL_07  07 /* Margin proportionate Inc/Dec w.r.t allowed bytes */
+
+/*
+ * Configures credit availability to be calculated along with the
+ * bytes in flight within in the allowed margin offset
+ */
+#define SPDK_NVMF_RDMA_IO_PACER_ALLOW_WITHIN_CREDIT_ONLY			1
+#define SPDK_NVMF_RDMA_IO_PACER_DEFAULT_MARGIN_ABOVE_CREDIT			1
+
+/*
+ * Configure IO request to be processed only when within in the bytes flight
+*/
+#define SPDK_NVMF_RDMA_IO_PACER_ALLOW_IO_WITHIN_AVAIL				0
+
 struct spdk_io_pacer;
 struct spdk_io_pacer_tuner;
 struct spdk_io_pacer_tuner2;
@@ -68,7 +94,8 @@ typedef void (*spdk_io_pacer_pop_cb)(void *io);
 struct spdk_io_pacer *spdk_io_pacer_create(uint32_t period_ns,
 					   uint32_t credit,
 					   uint32_t disk_credit,
-					   spdk_io_pacer_pop_cb pop_cb);
+					   spdk_io_pacer_pop_cb pop_cb,
+					   uint32_t	io_pacer_tuner_type);
 void spdk_io_pacer_destroy(struct spdk_io_pacer *pacer);
 int spdk_io_pacer_create_queue(struct spdk_io_pacer *pacer, uint64_t key);
 int spdk_io_pacer_destroy_queue(struct spdk_io_pacer *pacer, uint64_t key);
@@ -88,6 +115,8 @@ struct spdk_io_pacer_tuner2 *spdk_io_pacer_tuner2_create(struct spdk_io_pacer *p
 void spdk_io_pacer_tuner2_destroy(struct spdk_io_pacer_tuner2 *tuner);
 void spdk_io_pacer_tuner2_add(struct spdk_io_pacer_tuner2 *tuner, uint32_t value);
 void spdk_io_pacer_tuner2_sub(struct spdk_io_pacer_tuner2 *tuner, uint32_t value);
+
+bool is_credit_available(struct spdk_io_pacer *pacer);
 
 static inline void drive_stats_lock(struct spdk_io_pacer_drives_stats *stats) {
 	rte_spinlock_lock(&stats->lock);


### PR DESCRIPTION
Added functions to control the cache eviction

Root Cause: 
Assigned credit for a pacer period is utilized without considering the bytes in flight.
Hence bytes flight increases a lot above the allowed maximum threshold level and leading to the cache eviction & leading to cache miss.

Fix info:
Added the below functions to control the cache eviction
1. is_credit_available() - When credit availably checked, also checking bytes in flight is with in the maximum allowed bytes
   Default enabled with the macro SPDK_NVMF_RDMA_IO_PACER_ALLOW_WITHIN_CREDIT_ONLY

2. is_entry_size_within_limit() - When processing the request from the pacer check if the request size is within in the allowed bytes range
   Default disabled with the macro SPDK_NVMF_RDMA_IO_PACER_ALLOW_IO_WITHIN_AVAIL - Reason to allow processing a single request to consider the slow disk/other slowness in processing the request

Added the macros to configure the tuner type and the proposals. Hence with the change will send the parameters from the test script to configure dynamically.

[Features/Functional areas and/or component interfaces affected]
General SPDK

[Whether the change affects how hardware is programmed]
Yes - Configures request out of pacer queue to be processed

Local testing:
Tested with Tuner2 - Test14 test case and below is the test result

test_14
CPU mask: 0xF0 Num cores:4 IO pacer period:5600 Adjusted period:22400
./test_NoArg.sh: line 336: 708492 Terminated              tail -f > rpc_pipe
| QD         | BW         |  BW Max     | WIRE BW    | AVG LAT, us     | BW STDDEV  | L3 Hit Rate     | Bufs in-flight (MiB) | Pacer period, us    
| 256        | 185.6      |  191.0      | 188.9947   | 2891.1          | .6         | 99.3            | 29.6 (3.7)           | 22.5