### PR TITLE
ci: fix new git behavior

### DIFF
--- a/.ci/build_deb.sh
+++ b/.ci/build_deb.sh
@@ -3,7 +3,7 @@
 # The script to (re)build SPDK DEB (Ubuntu) packags
 # from the checked out source tree (spdk subdir)
 
-branch=$(git name-rev --name-only HEAD | awk -F/ '{print $NF}')
+branch=$(git name-rev --name-only --refs *nvda* HEAD | awk -F/ '{print $NF}')
 sha1=$(git rev-parse HEAD |cut -c -8)
 BASEDIR=$(dirname "$0")
 ODIR=$(readlink -f $BASEDIR/../)

--- a/.ci/build_rpm.sh
+++ b/.ci/build_rpm.sh
@@ -25,7 +25,7 @@ mkdir -p $HOME/rpmbuild/{SOURCES,RPMS,SRPMS,SPECS,BUILD,BUILDROOT}
 OUTDIR=$HOME/rpmbuild/SOURCES
 set -e
 
-branch=$(git name-rev --name-only HEAD | awk -F/ '{print $NF}')
+branch=$(git name-rev --name-only --refs *nvda* HEAD | awk -F/ '{print $NF}')
 sha1=$(git rev-parse HEAD |cut -c -8)
 _date=$(date +'%a %b %d %Y')
 


### PR DESCRIPTION
In a new version of git an argument name-rev
returns tags instead a branch name

git name-rev --name-only HEAD | awk -F/ '{print $NF}' 
v22.05-28~1

Signed-off-by: Iaroslav Sydoruk <isydoruk@nvidia.com>