### PR TITLE
V22.05.nvda.pending.io

### DIFF
--- a/lib/nvmf/rdma.c
+++ b/lib/nvmf/rdma.c
@@ -644,11 +644,14 @@ nvmf_rdma_request_free_data(struct spdk_nvmf_rdma_request *rdma_req,
 		data_wr->wr.num_sge = 0;
 		next_send_wr = data_wr->wr.next;
 		if (data_wr != &rdma_req->data) {
+			data_wr->wr.next = NULL;
 			spdk_mempool_put(rtransport->data_wr_pool, data_wr);
 		}
 		data_wr = (!next_send_wr || next_send_wr == &rdma_req->rsp.wr) ? NULL :
 			  SPDK_CONTAINEROF(next_send_wr, struct spdk_nvmf_rdma_request_data, wr);
 	}
+	rdma_req->data.wr.next = NULL;
+	rdma_req->rsp.wr.next = NULL;
 }
 
 static void
@@ -1945,8 +1948,6 @@ _nvmf_rdma_request_free(struct spdk_nvmf_rdma_request *rdma_req,
 	rdma_req->req.length = 0;
 	rdma_req->req.iovcnt = 0;
 	rdma_req->req.data = NULL;
-	rdma_req->rsp.wr.next = NULL;
-	rdma_req->data.wr.next = NULL;
 	rdma_req->offset = 0;
 	rdma_req->req.dif_enabled = false;
 	rdma_req->fused_failed = false;


### PR DESCRIPTION
This is a target issue related with rdma.

Sometimes, the last requests from a qpair are pending in
pending_buf_queue due to lack of data_wr_pool, but nothing
may be reaped on the qair, so the pending requests will not
be handled anymore.

To fix it, pending_buf_queue will be checked in an idle poll.