### PR TITLE
external snapshots resync with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ function requires a bdev descriptor to be passed and the claim is automatically 
 descriptor is closed. It allows bdev modules to claim bdevs as a single writer, multiple writers, or
 multiple readers.
 
+### gpt
+
+GPT bdevs now use the GPT Unique Partition ID as the bdev's UUID.
+
 ### lvol
 
 New API `spdk_lvol_iter_immediate_clones` was added to iterate the clones of an lvol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ function requires a bdev descriptor to be passed and the claim is automatically 
 descriptor is closed. It allows bdev modules to claim bdevs as a single writer, multiple writers, or
 multiple readers.
 
-### gpt
-
-GPT bdevs now use the GPT Unique Partition ID as the bdev's UUID. Do not rely on the newly
-introduced spdk_bdev_part_construct_uuid(). A more flexible replacement will come later.
-
 ### lvol
 
 New API `spdk_lvol_iter_immediate_clones` was added to iterate the clones of an lvol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ volumes without providing information about the bdevs. It is useful for listing 
 associated with specific lvol stores and for listing lvols that are not healthy and have no
 associated bdev.
 
+### part
+
+New API `spdk_bdev_part_construct_ext` is added and allows the bdev's UUID to be specified.
+
 ## v23.01
 
 ### accel

--- a/doc/jsonrpc.md
+++ b/doc/jsonrpc.md
@@ -10066,7 +10066,7 @@ Example response:
     "is_snapshot": false,
     "is_clone": false,
     "is_esnap_clone": false,
-    "is_healthy": true,
+    "is_degraded": false,
     "lvs": {
       "name": "lvs_test",
       "uuid": "a1c8d950-5715-4558-936d-ab9e6eca0794"

--- a/include/spdk/bdev_module.h
+++ b/include/spdk/bdev_module.h
@@ -1463,6 +1463,24 @@ int spdk_bdev_part_base_construct_ext(const char *bdev_name,
 				      spdk_io_channel_destroy_cb ch_destroy_cb,
 				      struct spdk_bdev_part_base **base);
 
+/** Options used when constructing a part bdev. */
+struct spdk_bdev_part_construct_opts {
+	/* Size of this structure in bytes */
+	uint64_t opts_size;
+	/** UUID of the bdev */
+	struct spdk_uuid uuid;
+};
+
+SPDK_STATIC_ASSERT(sizeof(struct spdk_bdev_part_construct_opts) == 24, "Incorrect size");
+
+/**
+ * Initialize options that will be passed to spdk_bdev_part_construct_ext().
+ *
+ * \param opts Options structure to initialize
+ * \param size Size of opts structure.
+ */
+void spdk_bdev_part_construct_opts_init(struct spdk_bdev_part_construct_opts *opts, uint64_t size);
+
 /**
  * Create a logical spdk_bdev_part on top of a base.
  *
@@ -1479,6 +1497,25 @@ int spdk_bdev_part_base_construct_ext(const char *bdev_name,
 int spdk_bdev_part_construct(struct spdk_bdev_part *part, struct spdk_bdev_part_base *base,
 			     char *name, uint64_t offset_blocks, uint64_t num_blocks,
 			     char *product_name);
+
+/**
+ * Create a logical spdk_bdev_part on top of a base with a non-NULL bdev UUID
+ *
+ * \param part The part object allocated by the user.
+ * \param base The base from which to create the part.
+ * \param name The name of the new spdk_bdev_part.
+ * \param offset_blocks The offset into the base bdev at which this part begins.
+ * \param num_blocks The number of blocks that this part will span.
+ * \param product_name Unique name for this type of block device.
+ * \param opts Additional options.
+ *
+ * \return 0 on success.
+ * \return -1 if the bases underlying bdev cannot be claimed by the current module.
+ */
+int spdk_bdev_part_construct_ext(struct spdk_bdev_part *part, struct spdk_bdev_part_base *base,
+				 char *name, uint64_t offset_blocks, uint64_t num_blocks,
+				 char *product_name,
+				 const struct spdk_bdev_part_construct_opts *opts);
 
 /**
  * Forwards I/O from an spdk_bdev_part to the underlying base bdev.

--- a/include/spdk/bdev_module.h
+++ b/include/spdk/bdev_module.h
@@ -1481,24 +1481,6 @@ int spdk_bdev_part_construct(struct spdk_bdev_part *part, struct spdk_bdev_part_
 			     char *product_name);
 
 /**
- * Create a logical spdk_bdev_part on top of a base with a non-NULL bdev UUID
- *
- * \param part The part object allocated by the user.
- * \param base The base from which to create the part.
- * \param name The name of the new spdk_bdev_part.
- * \param offset_blocks The offset into the base bdev at which this part begins.
- * \param num_blocks The number of blocks that this part will span.
- * \param product_name Unique name for this type of block device.
- * \param uuid The bdev UUID.
- *
- * \return 0 on success.
- * \return -1 if the bases underlying bdev cannot be claimed by the current module.
- */
-int spdk_bdev_part_construct_uuid(struct spdk_bdev_part *part, struct spdk_bdev_part_base *base,
-				  char *name, uint64_t offset_blocks, uint64_t num_blocks,
-				  char *product_name, const struct spdk_uuid *uuid);
-
-/**
  * Forwards I/O from an spdk_bdev_part to the underlying base bdev.
  *
  * This function will apply the offset_blocks the user provided to

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -373,6 +373,14 @@ void spdk_lvol_inflate(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void
  */
 void spdk_lvol_decouple_parent(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *cb_arg);
 
+/**
+ * Determine if an lvol is degraded. A degraded lvol cannot perform IO.
+ *
+ * \param lvol Handle to lvol
+ * \return true if the lvol has no open blob or the lvol's blob is degraded, else false.
+ */
+bool spdk_lvol_is_degraded(const struct spdk_lvol *lvol);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/spdk/lvol.h
+++ b/include/spdk/lvol.h
@@ -224,11 +224,15 @@ void spdk_lvol_create_clone(struct spdk_lvol *lvol, const char *clone_name,
  *
  * \param esnap_id The identifier that will be passed to the spdk_bs_esnap_dev_create callback.
  * \param id_len The length of esnap_id, in bytes.
- * \param size_bytes The size of the external snapshot device, in bytes.
+ * \param size_bytes The size of the external snapshot device, in bytes. This must be an integer
+ * multiple of the lvolstore's cluster size. See \c cluster_sz in \struct spdk_lvs_opts.
  * \param lvs Handle to lvolstore.
  * \param clone_name Name of created clone.
  * \param cb_fn Completion callback.
  * \param cb_arg Completion callback custom arguments.
+ * \return 0 if parameters pass verification checks and the esnap creation is started, in which case
+ * the \c cb_fn will be used to report the completion status. If an error is encountered, a negative
+ * errno will be rurned and \c cb_fn will not be called.
  */
 int spdk_lvol_create_esnap_clone(const void *esnap_id, uint32_t id_len, uint64_t size_bytes,
 				 struct spdk_lvol_store *lvs, const char *clone_name,

--- a/lib/bdev/part.c
+++ b/lib/bdev/part.c
@@ -502,15 +502,6 @@ spdk_bdev_part_construct(struct spdk_bdev_part *part, struct spdk_bdev_part_base
 			 char *name, uint64_t offset_blocks, uint64_t num_blocks,
 			 char *product_name)
 {
-	return spdk_bdev_part_construct_uuid(part, base, name, offset_blocks, num_blocks,
-					     product_name, NULL);
-}
-
-int
-spdk_bdev_part_construct_uuid(struct spdk_bdev_part *part, struct spdk_bdev_part_base *base,
-			      char *name, uint64_t offset_blocks, uint64_t num_blocks,
-			      char *product_name, const struct spdk_uuid *uuid)
-{
 	int rc;
 	bool first_claimed = false;
 
@@ -542,10 +533,6 @@ spdk_bdev_part_construct_uuid(struct spdk_bdev_part *part, struct spdk_bdev_part
 		SPDK_ERRLOG("Failed to allocate product name for new part of bdev %s\n",
 			    spdk_bdev_get_name(base->bdev));
 		return -1;
-	}
-
-	if (uuid != NULL) {
-		spdk_uuid_copy(&part->internal.bdev.uuid, uuid);
 	}
 
 	base->ref++;

--- a/lib/bdev/spdk_bdev.map
+++ b/lib/bdev/spdk_bdev.map
@@ -152,7 +152,9 @@
 	spdk_bdev_part_free;
 	spdk_bdev_part_base_hotremove;
 	spdk_bdev_part_base_construct_ext;
+	spdk_bdev_part_construct_opts_init;
 	spdk_bdev_part_construct;
+	spdk_bdev_part_construct_ext;
 	spdk_bdev_part_submit_request;
 	spdk_bdev_part_submit_request_ext;
 	spdk_bdev_part_get_bdev;

--- a/lib/bdev/spdk_bdev.map
+++ b/lib/bdev/spdk_bdev.map
@@ -153,7 +153,6 @@
 	spdk_bdev_part_base_hotremove;
 	spdk_bdev_part_base_construct_ext;
 	spdk_bdev_part_construct;
-	spdk_bdev_part_construct_uuid;
 	spdk_bdev_part_submit_request;
 	spdk_bdev_part_submit_request_ext;
 	spdk_bdev_part_get_bdev;

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -2172,3 +2172,14 @@ spdk_lvol_get_by_names(const char *lvs_name, const char *lvol_name)
 	pthread_mutex_unlock(&g_lvol_stores_mutex);
 	return NULL;
 }
+
+bool
+spdk_lvol_is_degraded(const struct spdk_lvol *lvol)
+{
+	struct spdk_blob *blob = lvol->blob;
+
+	if (blob == NULL) {
+		return true;
+	}
+	return !spdk_blob_is_healthy(blob);
+}

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -1237,6 +1237,7 @@ spdk_lvol_create_esnap_clone(const void *esnap_id, uint32_t id_len, uint64_t siz
 	struct spdk_blob_store *bs;
 	struct spdk_lvol *lvol;
 	struct spdk_blob_opts opts;
+	uint64_t cluster_sz;
 	char *xattr_names[] = {LVOL_NAME, "uuid"};
 	int rc;
 
@@ -1251,6 +1252,14 @@ spdk_lvol_create_esnap_clone(const void *esnap_id, uint32_t id_len, uint64_t siz
 	}
 
 	bs = lvs->blobstore;
+
+	cluster_sz = spdk_bs_get_cluster_size(bs);
+	if ((size_bytes % cluster_sz) != 0) {
+		SPDK_ERRLOG("Cannot create '%s/%s': size %" PRIu64 " is not an integer multiple of "
+			    "cluster size %" PRIu64 "\n", lvs->name, clone_name, size_bytes,
+			    cluster_sz);
+		return -EINVAL;
+	}
 
 	req = calloc(1, sizeof(*req));
 	if (!req) {
@@ -1272,7 +1281,7 @@ spdk_lvol_create_esnap_clone(const void *esnap_id, uint32_t id_len, uint64_t siz
 	opts.esnap_id = esnap_id;
 	opts.esnap_id_len = id_len;
 	opts.thin_provision = true;
-	opts.num_clusters = spdk_divide_round_up(size_bytes, spdk_bs_get_cluster_size(bs));
+	opts.num_clusters = spdk_divide_round_up(size_bytes, cluster_sz);
 	opts.clear_method = lvol->clear_method;
 	opts.xattrs.count = SPDK_COUNTOF(xattr_names);
 	opts.xattrs.names = xattr_names;

--- a/lib/lvol/spdk_lvol.map
+++ b/lib/lvol/spdk_lvol.map
@@ -25,6 +25,7 @@
 	spdk_lvol_iter_immediate_clones;
 	spdk_lvol_get_by_uuid;
 	spdk_lvol_get_by_names;
+	spdk_lvol_is_degraded;
 
 	# internal functions
 	spdk_lvol_resize;

--- a/module/bdev/gpt/vbdev_gpt.c
+++ b/module/bdev/gpt/vbdev_gpt.c
@@ -315,7 +315,6 @@ vbdev_gpt_create_bdevs(struct gpt_base *gpt_base)
 		uint64_t lba_start = from_le64(&p->starting_lba);
 		uint64_t lba_end = from_le64(&p->ending_lba);
 		uint64_t partition_size = lba_end - lba_start + 1;
-		struct spdk_uuid *uuid;
 
 		if (lba_start == 0) {
 			continue;
@@ -354,9 +353,8 @@ vbdev_gpt_create_bdevs(struct gpt_base *gpt_base)
 			return -1;
 		}
 
-		uuid = (struct spdk_uuid *)&gpt->partitions[i].unique_partition_guid;
-		rc = spdk_bdev_part_construct_uuid(&d->part, gpt_base->part_base, name,
-						   lba_start, partition_size, "GPT Disk", uuid);
+		rc = spdk_bdev_part_construct(&d->part, gpt_base->part_base, name,
+					      lba_start, partition_size, "GPT Disk");
 		free(name);
 		if (rc) {
 			SPDK_ERRLOG("could not construct bdev part\n");

--- a/module/bdev/lvol/vbdev_lvol.c
+++ b/module/bdev/lvol/vbdev_lvol.c
@@ -653,7 +653,7 @@ _vbdev_lvol_destroy(struct spdk_lvol *lvol, spdk_lvol_op_complete cb_fn, void *c
 	ctx->cb_fn = cb_fn;
 	ctx->cb_arg = cb_arg;
 
-	if (!spdk_blob_is_healthy(lvol->blob)) {
+	if (spdk_lvol_is_degraded(lvol)) {
 		spdk_lvol_close(lvol, _vbdev_lvol_destroy_cb, ctx);
 		return;
 	}
@@ -1111,8 +1111,8 @@ _create_lvol_disk(struct spdk_lvol *lvol, bool destroy)
 	unsigned char *alias;
 	int rc;
 
-	if (!spdk_blob_is_healthy(lvol->blob)) {
-		SPDK_NOTICELOG("lvol %s: blob is not healthy: deferring bdev creation\n",
+	if (spdk_lvol_is_degraded(lvol)) {
+		SPDK_NOTICELOG("lvol %s: blob is degraded: deferring bdev creation\n",
 			       lvol->unique_id);
 		return 0;
 	}

--- a/module/bdev/lvol/vbdev_lvol.h
+++ b/module/bdev/lvol/vbdev_lvol.h
@@ -18,6 +18,7 @@ struct lvol_store_bdev {
 	struct spdk_lvol_store	*lvs;
 	struct spdk_bdev	*bdev;
 	struct spdk_lvs_req	*req;
+	bool			removal_in_progress;
 
 	TAILQ_ENTRY(lvol_store_bdev)	lvol_stores;
 };

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -1169,7 +1169,7 @@ rpc_dump_lvol(struct spdk_json_write_ctx *w, struct spdk_lvol *lvol)
 	spdk_json_write_named_bool(w, "is_snapshot", spdk_blob_is_snapshot(lvol->blob));
 	spdk_json_write_named_bool(w, "is_clone", spdk_blob_is_clone(lvol->blob));
 	spdk_json_write_named_bool(w, "is_esnap_clone", spdk_blob_is_esnap_clone(lvol->blob));
-	spdk_json_write_named_bool(w, "is_healthy", spdk_blob_is_healthy(lvol->blob));
+	spdk_json_write_named_bool(w, "is_degraded", !spdk_blob_is_healthy(lvol->blob));
 
 	spdk_json_write_named_object_begin(w, "lvs");
 	spdk_json_write_named_string(w, "name", lvs->name);

--- a/test/bdev/blockdev.sh
+++ b/test/bdev/blockdev.sh
@@ -118,13 +118,20 @@ function setup_gpt_conf() {
 		fi
 	done
 	if [[ -n $gpt_nvme ]]; then
+		# These Unique Partition GUIDs were randomly generated for testing and are distinct
+		# from the Partition Type GUIDs (SPDK_GPT_OLD_GUID and SPDK_GPT_GUID) which have
+		# special meaning to SPDK. See section 5.3.3 of UEFI Spec 2.3 for the distinction
+		# between Unique Partition GUID and Partition Type GUID.
+		typeset -g g_unique_partguid=6f89f330-603b-4116-ac73-2ca8eae53030
+		typeset -g g_unique_partguid_old=abf1734f-66e5-4c0f-aa29-4021d4d307df
+
 		# Create gpt partition table
 		parted -s "$gpt_nvme" mklabel gpt mkpart SPDK_TEST_first '0%' '50%' mkpart SPDK_TEST_second '50%' '100%'
 		# change the GUID to SPDK GUID value
 		SPDK_GPT_OLD_GUID=$(get_spdk_gpt_old)
 		SPDK_GPT_GUID=$(get_spdk_gpt)
-		sgdisk -t "1:$SPDK_GPT_GUID" "$gpt_nvme"
-		sgdisk -t "2:$SPDK_GPT_OLD_GUID" "$gpt_nvme"
+		sgdisk -t "1:$SPDK_GPT_GUID" -u "1:$g_unique_partguid" "$gpt_nvme"
+		sgdisk -t "2:$SPDK_GPT_OLD_GUID" -u "2:$g_unique_partguid_old" "$gpt_nvme"
 		"$rootdir/scripts/setup.sh"
 		"$rpc_py" bdev_get_bdevs
 		setup_nvme_conf
@@ -618,6 +625,27 @@ function stat_test_suite() {
 	trap - SIGINT SIGTERM EXIT
 }
 
+function bdev_gpt_uuid() {
+	local bdev
+
+	start_spdk_tgt
+
+	"$rpc_py" load_config -j "$conf_file"
+	"$rpc_py" bdev_wait_for_examine
+
+	bdev=$("$rpc_py" bdev_get_bdevs -b "$g_unique_partguid")
+	[[ "$(jq -r 'length' <<< "$bdev")" == "1" ]]
+	[[ "$(jq -r '.[0].aliases[0]' <<< "$bdev")" == "$g_unique_partguid" ]]
+	[[ "$(jq -r '.[0].driver_specific.gpt.unique_partition_guid' <<< "$bdev")" == "$g_unique_partguid" ]]
+
+	bdev=$("$rpc_py" bdev_get_bdevs -b "$g_unique_partguid_old")
+	[[ "$(jq -r 'length' <<< "$bdev")" == "1" ]]
+	[[ "$(jq -r '.[0].aliases[0]' <<< "$bdev")" == "$g_unique_partguid_old" ]]
+	[[ "$(jq -r '.[0].driver_specific.gpt.unique_partition_guid' <<< "$bdev")" == "$g_unique_partguid_old" ]]
+
+	killprocess "$spdk_tgt_pid"
+}
+
 # Initial bdev creation and configuration
 #-----------------------------------------------------
 QOS_DEV_1="Malloc_0"
@@ -754,6 +782,10 @@ if [[ $test_type == bdev ]]; then
 	run_test "bdev_qd_sampling" qd_sampling_test_suite "$env_ctx"
 	run_test "bdev_error" error_test_suite "$env_ctx"
 	run_test "bdev_stat" stat_test_suite "$env_ctx"
+fi
+
+if [[ $test_type == gpt ]]; then
+	run_test "bdev_gpt_uuid" bdev_gpt_uuid
 fi
 
 # Temporarily disabled - infinite loop

--- a/test/lvol/esnap/esnap.c
+++ b/test/lvol/esnap/esnap.c
@@ -49,6 +49,7 @@ make_test_file(size_t size, char *path, size_t len, const char *name)
 	if (snprintf(path, len, "%s/%s", g_testdir, name) >= (int)len) {
 		return -ENAMETOOLONG;
 	}
+	unlink(path);
 	fd = open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
 	if (fd < 0) {
 		return -errno;

--- a/test/lvol/esnap/esnap.c
+++ b/test/lvol/esnap/esnap.c
@@ -673,6 +673,91 @@ esnap_remove_unhealthy(void)
 }
 
 static void
+late_delete(void)
+{
+	char aiopath[PATH_MAX];
+	struct spdk_lvol_store *lvs = NULL;
+	const uint32_t bs_size_bytes = 10 * 1024 * 1024;
+	const uint32_t bs_block_size = 4096;
+	const uint32_t cluster_size = 32 * 1024;
+	struct op_with_handle_data owh_data;
+	struct lvol_bdev *lvol_bdev;
+	struct spdk_lvol *lvol;
+	int rc, rc2;
+	int count;
+
+	/* Create device for lvstore. This cannot be a malloc bdev because we need to sneak a
+	 * deletion in while blob_persist() is in progress.
+	 */
+	rc = make_test_file(bs_size_bytes, aiopath, sizeof(aiopath), "late_delete.aio");
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	rc = create_aio_bdev("aio1", aiopath, bs_block_size, false);
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	poll_threads();
+
+	/* Create lvstore */
+	rc = vbdev_lvs_create("aio1", "lvs1", cluster_size, 0, 0,
+			      lvs_op_with_handle_cb, clear_owh(&owh_data));
+	SPDK_CU_ASSERT_FATAL(rc == 0);
+	poll_error_updated(&owh_data.lvserrno);
+	SPDK_CU_ASSERT_FATAL(owh_data.lvserrno == 0);
+	SPDK_CU_ASSERT_FATAL(owh_data.u.lvs != NULL);
+	lvs = owh_data.u.lvs;
+
+	/* Create an lvol */
+	vbdev_lvol_create(lvs, "lvol", 1, true, LVOL_CLEAR_WITH_DEFAULT,
+			  lvol_op_with_handle_cb, clear_owh(&owh_data));
+	poll_error_updated(&owh_data.lvserrno);
+	CU_ASSERT(owh_data.lvserrno == 0);
+	CU_ASSERT(owh_data.u.lvol != NULL);
+
+	/* Verify the lvol can be found both ways */
+	CU_ASSERT(spdk_bdev_get_by_name("lvs1/lvol") != NULL);
+	CU_ASSERT(spdk_lvol_get_by_names("lvs1", "lvol") != NULL);
+
+	/*
+	 * Once the lvolstore deletion starts, it will briefly be possible to look up lvol bdevs and
+	 * degraded lvols in that lvolstore but any attempt to delete them will fail with -ENODEV.
+	 */
+	rc = 0xbad;
+	count = 0;
+	vbdev_lvs_destruct(lvs, lvol_op_complete_cb, &rc);
+	do {
+		lvol_bdev = (struct lvol_bdev *)spdk_bdev_get_by_name("lvs1/lvol");
+		if (lvol_bdev != NULL) {
+			rc2 = 0xbad;
+			vbdev_lvol_destroy(lvol_bdev->lvol, lvol_op_complete_cb, &rc2);
+			CU_ASSERT(rc2 == -ENODEV);
+		}
+		lvol = spdk_lvol_get_by_names("lvs1", "lvol");
+		if (lvol != NULL) {
+			/* If we are here, we are likely reproducing #2998 */
+			rc2 = 0xbad;
+			vbdev_lvol_destroy(lvol, lvol_op_complete_cb, &rc2);
+			CU_ASSERT(rc2 == -ENODEV);
+			count++;
+		}
+
+		spdk_thread_poll(g_ut_threads[0].thread, 0, 0);
+	} while (rc == 0xbad);
+
+	/* Ensure that the test exercised the race */
+	CU_ASSERT(count != 0);
+
+	/* The lvol is now gone */
+	CU_ASSERT(spdk_bdev_get_by_name("lvs1/lvol") == NULL);
+	CU_ASSERT(spdk_lvol_get_by_names("lvs1", "lvol") == NULL);
+
+	/* Clean up */
+	rc = 0xbad;
+	bdev_aio_delete("aio1", unregister_cb, &rc);
+	poll_error_updated(&rc);
+	CU_ASSERT(rc == 0);
+	rc = unlink(aiopath);
+	CU_ASSERT(rc == 0);
+}
+
+static void
 bdev_init_cb(void *arg, int rc)
 {
 	assert(rc == 0);
@@ -706,6 +791,7 @@ main(int argc, char **argv)
 	CU_ADD_TEST(suite, esnap_clone_io);
 	CU_ADD_TEST(suite, esnap_hotplug);
 	CU_ADD_TEST(suite, esnap_remove_unhealthy);
+	CU_ADD_TEST(suite, late_delete);
 
 	allocate_threads(2);
 	set_thread(0);

--- a/test/lvol/external_snapshot.sh
+++ b/test/lvol/external_snapshot.sh
@@ -102,7 +102,7 @@ function test_esnap_reload_missing() {
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '. | length' <<< "$lvols")" == "1" ]
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "false" ]
 
 	# Unload the lvstore and delete the external snapshot
 	rpc_cmd bdev_aio_delete "$aio_bdev"
@@ -117,7 +117,7 @@ function test_esnap_reload_missing() {
 	NOT rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '. | length' <<< "$lvols")" == "1" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "true" ]
 
 	# Reload the lvstore with esnap present during load. This should make the lvol healthy.
 	# State:
@@ -132,7 +132,7 @@ function test_esnap_reload_missing() {
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '. | length' <<< "$lvols")" == "1" ]
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "false" ]
 
 	# Create a clone of eclone, then reload without the esnap present.
 	# State:
@@ -147,9 +147,9 @@ function test_esnap_reload_missing() {
 	bs_dev=$(rpc_cmd bdev_aio_create "$testdir/aio_bdev_0" "$aio_bdev" "$block_size")
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "true" ]
 	[ "$(jq -r '.[] | select(.name == "clone").is_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "true" ]
 	NOT rpc_cmd bdev_get_bdevs -b lvs_test/eclone
 	NOT rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	NOT rpc_cmd bdev_get_bdevs -b lvs_test/clone
@@ -164,9 +164,9 @@ function test_esnap_reload_missing() {
 	bs_dev=$(rpc_cmd bdev_aio_create "$testdir/aio_bdev_0" "$aio_bdev" "$block_size")
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "false" ]
 	[ "$(jq -r '.[] | select(.name == "clone").is_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "clone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "clone").is_degraded' <<< "$lvols")" == "false" ]
 	rpc_cmd bdev_get_bdevs -b lvs_test/eclone
 	rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	rpc_cmd bdev_get_bdevs -b lvs_test/clone
@@ -184,12 +184,12 @@ function test_esnap_reload_missing() {
 	bs_dev=$(rpc_cmd bdev_aio_create "$testdir/aio_bdev_0" "$aio_bdev" "$block_size")
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "true" ]
 	[ "$(jq -r '.[] | select(.name == "clone").is_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "clone").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "clone").is_degraded' <<< "$lvols")" == "true" ]
 	[ "$(jq -r '.[] | select(.name == "snap").is_clone' <<< "$lvols")" == "true" ]
 	[ "$(jq -r '.[] | select(.name == "snap").is_snapshot' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "snap").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.name == "snap").is_degraded' <<< "$lvols")" == "true" ]
 	NOT rpc_cmd bdev_get_bdevs -b lvs_test/eclone
 	NOT rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	NOT rpc_cmd bdev_get_bdevs -b lvs_test/clone
@@ -202,12 +202,12 @@ function test_esnap_reload_missing() {
 	rpc_cmd bdev_wait_for_examine
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '.[] | select(.name == "eclone").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "eclone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "eclone").is_degraded' <<< "$lvols")" == "false" ]
 	[ "$(jq -r '.[] | select(.name == "clone").is_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "clone").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "clone").is_degraded' <<< "$lvols")" == "false" ]
 	[ "$(jq -r '.[] | select(.name == "snap").is_clone' <<< "$lvols")" == "true" ]
 	[ "$(jq -r '.[] | select(.name == "snap").is_snapshot' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.name == "snap").is_healthy' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.name == "snap").is_degraded' <<< "$lvols")" == "false" ]
 	rpc_cmd bdev_get_bdevs -b lvs_test/eclone
 	rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	rpc_cmd bdev_get_bdevs -b lvs_test/clone
@@ -415,7 +415,7 @@ function test_esnap_late_arrival() {
 	NOT rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
 	[ "$(jq -r '.[] | select(.uuid == "'$eclone_uuid'").is_esnap_clone' <<< "$lvols")" == "true" ]
-	[ "$(jq -r '.[] | select(.uuid == "'$eclone_uuid'").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.uuid == "'$eclone_uuid'").is_degraded' <<< "$lvols")" == "true" ]
 
 	# Create the esnap device and verify that the esnap clone finds it.
 	esnap_dev=$(rpc_cmd bdev_malloc_create -u "$esnap_uuid" "$esnap_size_mb" "$block_size")
@@ -462,8 +462,8 @@ function test_esnap_remove_unhealthy() {
 
 	# Verify clone and eclone are not healhty
 	lvols=$(rpc_cmd bdev_lvol_get_lvols)
-	[ "$(jq -r '.[] | select(.uuid == "'$eclone_uuid'").is_healthy' <<< "$lvols")" == "false" ]
-	[ "$(jq -r '.[] | select(.uuid == "'$clone_uuid'").is_healthy' <<< "$lvols")" == "false" ]
+	[ "$(jq -r '.[] | select(.uuid == "'$eclone_uuid'").is_degraded' <<< "$lvols")" == "true" ]
+	[ "$(jq -r '.[] | select(.uuid == "'$clone_uuid'").is_degraded' <<< "$lvols")" == "true" ]
 	NOT rpc_cmd bdev_get_bdevs -b "$clone_uuid"
 	NOT rpc_cmd bdev_get_bdevs -b "$eclone_uuid"
 

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -48,8 +48,8 @@ DEFINE_STUB(spdk_lvol_iter_immediate_clones, int,
 DEFINE_STUB(spdk_lvs_esnap_missing_add, int,
 	    (struct spdk_lvol_store *lvs, struct spdk_lvol *lvol, const void *esnap_id,
 	     uint32_t id_len), -ENOTSUP);
-DEFINE_STUB(spdk_blob_is_healthy, bool, (const struct spdk_blob *blob), true);
 DEFINE_STUB(spdk_blob_get_esnap_bs_dev, struct spdk_bs_dev *, (const struct spdk_blob *blob), NULL);
+DEFINE_STUB(spdk_lvol_is_degraded, bool, (const struct spdk_lvol *lvol), false);
 
 struct spdk_blob {
 	uint64_t	id;
@@ -1800,7 +1800,7 @@ ut_esnap_dev_create(void)
 
 	/* Bdev not found */
 	g_base_bdev = NULL;
-	MOCK_SET(spdk_blob_is_healthy, false);
+	MOCK_SET(spdk_lvol_is_degraded, true);
 	rc = vbdev_lvol_esnap_dev_create(&lvs, &lvol, &blob, uuid_str, sizeof(uuid_str), &bs_dev);
 	CU_ASSERT(rc == 0);
 	SPDK_CU_ASSERT_FATAL(bs_dev != NULL);
@@ -1811,7 +1811,7 @@ ut_esnap_dev_create(void)
 	/* TODO: This suggests we need a way to wait for a claim to be available. */
 	g_base_bdev = &bdev;
 	lvol_already_opened = true;
-	MOCK_SET(spdk_blob_is_healthy, false);
+	MOCK_SET(spdk_lvol_is_degraded, true);
 	rc = vbdev_lvol_esnap_dev_create(&lvs, &lvol, &blob, uuid_str, sizeof(uuid_str), &bs_dev);
 	CU_ASSERT(rc == 0);
 	SPDK_CU_ASSERT_FATAL(bs_dev != NULL);
@@ -1820,7 +1820,7 @@ ut_esnap_dev_create(void)
 
 	/* Happy path */
 	lvol_already_opened = false;
-	MOCK_SET(spdk_blob_is_healthy, true);
+	MOCK_SET(spdk_lvol_is_degraded, false);
 	rc = vbdev_lvol_esnap_dev_create(&lvs, &lvol, &blob, uuid_str, sizeof(uuid_str), &bs_dev);
 	CU_ASSERT(rc == 0);
 	SPDK_CU_ASSERT_FATAL(bs_dev != NULL);
@@ -1830,7 +1830,7 @@ ut_esnap_dev_create(void)
 	g_base_bdev = NULL;
 	lvol_already_opened = false;
 	free(unterminated);
-	MOCK_CLEAR(spdk_blob_is_healthy);
+	MOCK_CLEAR(spdk_lvol_is_degraded);
 }
 
 static void

--- a/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
+++ b/test/unit/lib/bdev/vbdev_lvol.c/vbdev_lvol_ut.c
@@ -19,7 +19,6 @@ int g_lvserrno;
 int g_cluster_size;
 int g_registered_bdevs;
 int g_num_lvols = 0;
-int g_lvol_open_enomem = -1;
 struct spdk_lvol_store *g_lvs = NULL;
 struct spdk_lvol *g_lvol = NULL;
 struct lvol_store_bdev *g_lvs_bdev = NULL;
@@ -224,16 +223,7 @@ spdk_lvol_rename(struct spdk_lvol *lvol, const char *new_name,
 void
 spdk_lvol_open(struct spdk_lvol *lvol, spdk_lvol_op_with_handle_complete cb_fn, void *cb_arg)
 {
-	int lvolerrno;
-
-	if (g_lvol_open_enomem == lvol->lvol_store->lvols_opened) {
-		lvolerrno = -ENOMEM;
-		g_lvol_open_enomem = -1;
-	} else {
-		lvolerrno = g_lvolerrno;
-	}
-
-	cb_fn(cb_arg, lvol, lvolerrno);
+	cb_fn(cb_arg, lvol, g_lvolerrno);
 }
 
 uint64_t
@@ -350,12 +340,10 @@ lvs_load(struct spdk_bs_dev *dev, const struct spdk_lvs_opts *lvs_opts,
 	SPDK_CU_ASSERT_FATAL(lvs->blobstore != NULL);
 	TAILQ_INIT(&lvs->lvols);
 	TAILQ_INIT(&lvs->pending_lvols);
-	TAILQ_INIT(&lvs->retry_open_lvols);
 	spdk_uuid_generate(&lvs->uuid);
 	lvs->bs_dev = dev;
 	for (i = 0; i < g_num_lvols; i++) {
 		_lvol_create(lvs);
-		lvs->lvol_count++;
 	}
 
 	cb_fn(cb_arg, lvs, lvserrno);
@@ -1179,7 +1167,6 @@ ut_lvs_examine_check(bool success)
 		SPDK_CU_ASSERT_FATAL(g_lvol_store->blobstore != NULL);
 		CU_ASSERT(g_lvol_store->blobstore->esnap_bs_dev_create != NULL);
 		CU_ASSERT(g_lvol_store->bs_dev != NULL);
-		CU_ASSERT(g_lvol_store->lvols_opened == spdk_min(g_num_lvols, g_registered_bdevs));
 	} else {
 		SPDK_CU_ASSERT_FATAL(TAILQ_EMPTY(&g_spdk_lvol_pairs));
 		g_lvol_store = NULL;
@@ -1225,29 +1212,6 @@ ut_lvol_examine_disk(void)
 	vbdev_lvs_examine_disk(&g_bdev);
 	ut_lvs_examine_check(true);
 	CU_ASSERT(g_registered_bdevs != 0);
-	SPDK_CU_ASSERT_FATAL(!TAILQ_EMPTY(&g_lvol_store->lvols));
-	vbdev_lvs_destruct(g_lvol_store, lvol_store_op_complete, NULL);
-	CU_ASSERT(g_lvserrno == 0);
-
-	/* Examine multiple lvols successfully */
-	g_num_lvols = 4;
-	g_registered_bdevs = 0;
-	lvol_already_opened = false;
-	vbdev_lvs_examine_disk(&g_bdev);
-	ut_lvs_examine_check(true);
-	CU_ASSERT(g_registered_bdevs == g_num_lvols);
-	SPDK_CU_ASSERT_FATAL(!TAILQ_EMPTY(&g_lvol_store->lvols));
-	vbdev_lvs_destruct(g_lvol_store, lvol_store_op_complete, NULL);
-	CU_ASSERT(g_lvserrno == 0);
-
-	/* Examine multiple lvols successfully - fail one with -ENOMEM on lvol open */
-	g_num_lvols = 4;
-	g_lvol_open_enomem = 2;
-	g_registered_bdevs = 0;
-	lvol_already_opened = false;
-	vbdev_lvs_examine_disk(&g_bdev);
-	ut_lvs_examine_check(true);
-	CU_ASSERT(g_registered_bdevs == g_num_lvols);
 	SPDK_CU_ASSERT_FATAL(!TAILQ_EMPTY(&g_lvol_store->lvols));
 	vbdev_lvs_destruct(g_lvol_store, lvol_store_op_complete, NULL);
 	CU_ASSERT(g_lvserrno == 0);

--- a/test/unit/lib/lvol/lvol.c/lvol_ut.c
+++ b/test/unit/lib/lvol/lvol.c/lvol_ut.c
@@ -35,6 +35,7 @@ DEFINE_STUB(spdk_bdev_create_bs_dev_ro, int,
 	    (const char *bdev_name, spdk_bdev_event_cb_t event_cb, void *event_ctx,
 	     struct spdk_bs_dev **bs_dev), -ENOTSUP);
 DEFINE_STUB(spdk_blob_is_esnap_clone, bool, (const struct spdk_blob *blob), false);
+DEFINE_STUB(spdk_blob_is_degraded, bool, (const struct spdk_blob *blob), false);
 
 const char *uuid = "828d9766-ae50-11e7-bd8d-001e67edf350";
 


### PR DESCRIPTION
This gets v23.01.nvda in sync with the esnap fixes present in spdk/master.  These are important because:

* 06de5ca53af9f0de637042017e192abe155fa35f fixes endian issues with the interim fix. Esnap clones created with original implementation will experience problems upgrading to the fixed version.
* df8e16ed7b2811e8aa4a888b6397c4e50249526a prevents IO errors when an esnap clone is not a multiple of the blobstore cluster boundary. This catches the problem when creating the esnap clone rather than when something tries to perform IO on the last few blocks.
* ae42dfc53316d30ba2d001948dbb13666e0c64a2 eliminates a race during lvolstore deletion that could lead to a crash. *This crash can happen even with external snapshots are not used.*

The remaining commits are included in support of those listed above.