### PR TITLE
ci: disable x86 builds

### DIFF
--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -29,15 +29,16 @@ env:
   MOFED_VER: 23.07-0.5.0.0
 
 runs_on_dockers:
-  - {file: '.ci/Dockerfile.ubuntu20.04', name: 'ubuntu20_04', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
   - {file: '.ci/Dockerfile.ubuntu20.04', name: 'ubuntu20_04', arch: 'aarch64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
-  - {file: '.ci/Dockerfile.ubuntu22.04', name: 'ubuntu22_04', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
   - {file: '.ci/Dockerfile.ubuntu22.04', name: 'ubuntu22_04', arch: 'aarch64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
-  - {file: '.ci/Dockerfile.centos7.9.2009', name: 'centos7_9', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
   - {file: '.ci/Dockerfile.centos7.9.2009', name: 'centos7_9', arch: 'aarch64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
-  - {file: '.ci/Dockerfile.centos8', name: 'centos8_stream', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
   - {file: '.ci/Dockerfile.centos8', name: 'centos8_stream', arch: 'aarch64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
   - {file: '.ci/Dockerfile.openeuler.20.03', name: 'openeuler20_03', arch: 'aarch64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
+#  - {file: '.ci/Dockerfile.ubuntu20.04', name: 'ubuntu20_04', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
+#  - {file: '.ci/Dockerfile.ubuntu22.04', name: 'ubuntu22_04', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
+#  - {file: '.ci/Dockerfile.centos7.9.2009', name: 'centos7_9', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
+#  - {file: '.ci/Dockerfile.centos8', name: 'centos8_stream', arch: 'x86_64', build_args: '--build-arg MOFED_VER=$MOFED_VER', tag: '$MOFED_VER'}
+
 
 steps:
   - name: Set correct rights


### PR DESCRIPTION
We don't need to run x86 build check in CI.