### PR TITLE
fsdev: Unmask O_DRIECT for openat /proc/self/fd

### DIFF
--- a/module/fsdev/aio/fsdev_aio.c
+++ b/module/fsdev/aio/fsdev_aio.c
@@ -962,6 +962,8 @@ lo_open(struct spdk_io_channel *ch, struct spdk_fsdev_io *fsdev_io)
 		flags &= ~O_APPEND;
 	}
 
+	flags &= ~O_DIRECT;
+
 	sprintf(buf, "%i", lo_fd(vfsdev, ino));
 	fd = openat(vfsdev->proc_self_fd, buf, flags & ~O_NOFOLLOW);
 	if (fd == -1) {


### PR DESCRIPTION
Remove the O_DIRECT flag since openat doesn't support open symbolic link. But in /proc/self/fd they are all symbolic.