### PR TITLE
doca-nvmf-target-offload/ci: cloud launch on POD agent

### DIFF
--- a/.ci/Jenkinsfile.shlib
+++ b/.ci/Jenkinsfile.shlib
@@ -5,4 +5,22 @@
 @Library('github.com/Mellanox/ci-demo@stable_storage')
 def matrix = new com.mellanox.cicd.Matrix()
 
-matrix.main()
+def label = "worker-${UUID.randomUUID().toString()}"
+
+
+println("Cloud launch on ${label}")
+
+// JNLP location:
+// https://gitlab-master.nvidia.com/nbu-swx/storage/snap-verification/-/blob/master/docker/ci/
+podTemplate(
+    label: label,
+    containers: [
+        containerTemplate(
+            name: 'jnlp',
+            image: 'nbu-harbor.gtm.nvidia.com/swx-storage/arc/amd64/swx-storage-jnlp:20250519-1',
+            args: '${computer.jnlpmac} ${computer.name}'
+        )
+    ]
+) {
+    matrix.startPipeline(label)
+}


### PR DESCRIPTION
Run the pipeline on POD agent instead of the main Jenkins node.

Signed-off-by: Iaroslav Sydoruk <isydoruk@nvidia.com>