### PR TITLE
nvmf-target-offload/ci: fixed NGC path

### DIFF
--- a/.ci/Dockerfile.doca
+++ b/.ci/Dockerfile.doca
@@ -56,11 +56,11 @@ RUN set -eux; \
     else \
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VER}/files/ngccli_linux.zip"; \
     fi; \
-    wget --content-disposition $NGC_CLI_URL -O ngccli_linux.zip && \
-    unzip ngccli_linux.zip && \
-    chmod u+x ngc-cli/ngc && \
+    wget --content-disposition $NGC_CLI_URL -O /ngccli_linux.zip && \
+    unzip /ngccli_linux.zip -d / && \
+    chmod u+x /ngc-cli/ngc && \
     ln -s /ngc-cli/ngc /usr/bin/ngc && \
-    rm -f ngccli_linux.zip
+    rm -f /ngccli_linux.zip
 
 ### APT-CLEAN ###
 RUN apt clean && rm -rf /var/lib/apt/lists/*

--- a/.ci/ci_env.sh
+++ b/.ci/ci_env.sh
@@ -33,4 +33,4 @@ export CI_ENV_DOCKER_AARCH64="urm.nvidia.com/quay-remote/podman/stable:v5.3.2"
 # changes that affect components in CI builder images.
 # CI builder images use it as docker tag.
 # Format=<YYMMDD>-<ID>
-export CI_ENV_CI_REV="250616-1"
+export CI_ENV_CI_REV="250616-2"


### PR DESCRIPTION
ls: cannot access '/ngc-cli/ngc': No such file or directory

Signed-off-by: Iaroslav Sydoruk <isydoruk@nvidia.com>